### PR TITLE
Added ability to set the bot's status

### DIFF
--- a/src/commands/mods.js
+++ b/src/commands/mods.js
@@ -1,5 +1,5 @@
 //
-// Written by Su386.
+// Written by Su386 and J10a1n15.
 // See LICENSE for copyright and license notices.
 //
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,0 +1,104 @@
+//
+// Written by J10a1n15.
+// See LICENSE for copyright and license notices.
+//
+
+
+const { EmbedBuilder, SlashCommandBuilder } = require('discord.js');
+const fs = require("fs");
+const config = require("../config/config.json")
+
+const subcommands = {
+    set: { name: "set", function: handleSetCommand },
+    toggle : { name: "toggle", function: handleToggleCommand },
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("status")
+        .setDescription("Set the status of the bot")
+        .addSubcommand(subcommand => subcommand
+            .setName("set")
+            .setDescription("Set the status of the bot")
+            .addStringOption(option => option
+                .setName("status")
+                .setDescription("The status to set")
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Online', value: 'online' },
+                    { name: 'Idle', value: 'idle' },
+                    { name: 'Do not disturb', value: 'dnd' },
+                    { name: 'Invisible', value: 'invisible' }
+                )
+            )
+            .addStringOption(option => option
+                .setName("type")
+                .setDescription("The type of activity to set")
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Playing', value: 'PLAYING' },
+                    { name: 'Streaming', value: 'STREAMING' },
+                    { name: 'Listening', value: 'LISTENING' },
+                    { name: 'Watching', value: 'WATCHING' },
+                    { name: 'Competing', value: 'COMPETING' }
+                ),
+            )
+            .addStringOption(option => option
+                .setName("text")
+                .setDescription("The text to set")
+                .setRequired(true)
+            )
+        )
+        .addSubcommand(subcommand => subcommand
+            .setName("toggle")
+            .setDescription("Toggle the status of the bot")
+        ),
+    async run(client, interaction) {
+        if (!config.allowedAnnouncementUsers.includes(interaction.member.id))
+            return interaction.reply(`You do not have permission to use this command!`)
+
+        const subcommand = interaction.options.getSubcommand();
+        if (subcommands[subcommand]) {
+            subcommands[subcommand].function(interaction);
+        }
+    }
+};
+
+async function handleSetCommand(interaction) {
+    const status = interaction.options.getString("status");
+    const type = interaction.options.getString("type");
+    const text = interaction.options.getString("text");
+
+    writeStatus(status, type, text);
+
+    const embed = new EmbedBuilder()
+        .setTitle("Status")
+        .setDescription(`Set the status to ${status} with activity ${type} and text ${text}`)
+        .setColor(config.color)
+
+    await interaction.reply({ embeds: [embed] });
+}
+
+async function handleToggleCommand(interaction) {
+    const active = !config.status.active
+
+    writeStatus(config.status.status, config.status.type, config.status.text, active);
+
+    const embed = new EmbedBuilder()
+        .setTitle("Status")
+        .setDescription(`Set the status to ${active ? "active" : "inactive"}`)
+        .setColor(config.color)
+
+    await interaction.reply({ embeds: [embed] });
+}
+
+function writeStatus(status, type, text, active = config.status.active) {
+    config.status = {
+        active: active,
+        status: status,
+        type: type,
+        text: text
+    }
+
+    fs.writeFileSync("./src/config/config.json", JSON.stringify(config, null, 4))
+}

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -9,5 +9,11 @@
         "580396491416403989",
         "283738275552821248",
         "766070817351139379"
-    ]
+    ],
+    "status": {
+        "active": true,
+        "status": "online",
+        "type": "PLAYING",
+        "text": "on Hypixel Skyblock"
+    }
 }

--- a/src/events/loader.js
+++ b/src/events/loader.js
@@ -11,6 +11,7 @@ module.exports = async (client) => {
     client.commands = new Collection();
     require("./onCommandExec")(client);
     require("./onAutoComplete")(client);
+    require("./setBotStatus")(client);
 
     /* 
      * Load commands

--- a/src/events/setBotStatus
+++ b/src/events/setBotStatus
@@ -1,0 +1,35 @@
+//
+// Written by J10a1n15.
+// See LICENSE for copyright and license notices.
+//
+
+const { ActivityType } = require("discord.js")
+const config = require("../config/config.json")
+
+module.exports = async (client) => {
+    setInterval(() => {
+        const text = config.status.text
+        const type = translateType(config.status.type)
+        if (config.status.active == true) {
+            client.user.setActivity(text, { type: type })
+        } else {
+            client.user.setActivity(null)
+        }
+        client.user.setStatus(config.status.status)
+    }, 3 * 1000)
+}
+
+function translateType(type) {
+    switch (type) {
+        case "PLAYING":
+            return ActivityType.Playing
+        case "STREAMING":
+            return ActivityType.Streaming
+        case "LISTENING":
+            return ActivityType.Listening
+        case "WATCHING":
+            return ActivityType.Watching
+        case "COMPETING":
+            return ActivityType.Competing
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to set the status of the bot. It includes a new slash command called "status" with subcommands "set" and "toggle". The "set" subcommand allows users to set the status, type, and text of the bot's activity. The "toggle" subcommand allows users to toggle the bot's status between active and inactive.